### PR TITLE
Надо, чтобы before_* колбек возвращал что-то сравнимое с false

### DIFF
--- a/lib/delayed/job.rb
+++ b/lib/delayed/job.rb
@@ -40,6 +40,7 @@ module Delayed
     before_save do
       # Вычитаем 1 час для того чтобы run_at не оказывалось в будущем, если времена на серверах разойдуться.
       self.run_at ||= self.class.db_time_now - 1.hour
+      true
     end
 
     # When a worker is exiting, make sure we don't have any locked jobs.


### PR DESCRIPTION
Совмещаемся с 4 рельсами: https://stackoverflow.com/questions/36805639/rails-3-2-to-4-0-upgrade-undefined-method-to-datetime-for-falsefalseclass

Вылезло при апдейте рельсов до 4.0 в 1C приложении