### PR TITLE
Для джоб запускаемых через handle_asynchronously не из моделей ActiveRecord display_name генерился как "undefined#method".

### DIFF
--- a/lib/delayed/performable_method.rb
+++ b/lib/delayed/performable_method.rb
@@ -12,6 +12,8 @@ module Delayed
     end
 
     def display_name
+      return "#{self.object.class}#{method}" unless self.object.is_a?(String)
+
       case self.object
       when CLASS_STRING_FORMAT then "#{$1}.#{method}"
       when AR_STRING_FORMAT    then "#{$1}##{method}"


### PR DESCRIPTION
Из-за этого сложно разбираться если есть несколько одинаковых методов у разных классов.

Из-за этого в insales в DelayedJobStat пишутся не очень информативные хэндлеры `Unknown#upload_async_without_send_later`